### PR TITLE
Remove confusing log

### DIFF
--- a/lib/grpc_health_check.ex
+++ b/lib/grpc_health_check.ex
@@ -3,8 +3,6 @@ defmodule GrpcHealthCheck do
   use Application
 
   def start(_type, _args) do
-    Logger.info "GRPC Healthcheck started"
-
     children = []
 
     opts = [strategy: :one_for_one, name: GrpcHealthCheck]


### PR DESCRIPTION
This log was rather confusing because it can trick you into thinking that GRPC server started.