### PR TITLE
Add configuration option to disable info log messages

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,1 +1,3 @@
 use Mix.Config
+
+config :gprc_health_check, verbose_log: false

--- a/lib/grpc_health_check.ex
+++ b/lib/grpc_health_check.ex
@@ -8,4 +8,14 @@ defmodule GrpcHealthCheck do
     opts = [strategy: :one_for_one, name: GrpcHealthCheck]
     Supervisor.start_link(children, opts)
   end
+
+  def verbose_log(msg) do
+    if logs_enabled?() do
+      Logger.info(msg)
+    end
+  end
+
+  defp logs_enabled?() do
+    Application.get_env(:grpc_health_check, :verbose_log, false) == true
+  end
 end

--- a/lib/grpc_health_check/client.ex
+++ b/lib/grpc_health_check/client.ex
@@ -1,6 +1,4 @@
 defmodule GrpcHealthCheck.Client do
-  require Logger
-
   def call do
     Application.ensure_all_started(:gun)
 
@@ -9,6 +7,6 @@ defmodule GrpcHealthCheck.Client do
 
     {:ok, reply} = channel |> Grpc.Health.V1.Health.Stub.check(request)
 
-    Logger.info "Healthcheck request completed"
+    GrpcHealthCheck.verbose_log("Healthcheck request completed")
   end
 end

--- a/lib/grpc_health_check/server.ex
+++ b/lib/grpc_health_check/server.ex
@@ -1,14 +1,11 @@
 defmodule GrpcHealthCheck.Server do
   use GRPC.Server, service: Grpc.Health.V1.Health.Service
-  require Logger
 
   alias Grpc.Health.V1.HealthCheckResponse
 
   def check(_req, _stream) do
-    Logger.info "Received healthcheck request"
+    GrpcHealthCheck.verbose_log("Received healthcheck request")
 
-    HealthCheckResponse.new(
-      status: HealthCheckResponse.ServingStatus.value(:SERVING)
-    )
+    HealthCheckResponse.new(status: HealthCheckResponse.ServingStatus.value(:SERVING))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule GrpcHealthCheck.Mixfile do
       app: :grpc_health_check,
       version: "0.1.0",
       elixir: "~> 1.7",
-      start_permanent: Mix.env == :prod,
+      start_permanent: Mix.env() == :prod,
       deps: deps()
     ]
   end


### PR DESCRIPTION
In order to declutter logs of unnecessary messages, I've silenced information logs sent by this library. 
To support old behavior I've introduced `verbose_log` option. When set to true - logs will be printed.